### PR TITLE
Add EventList.from_neo_events, Allow compose_mainviewer_from_sources to use sources['event'] if present

### DIFF
--- a/ephyviewer/datasource/neosource.py
+++ b/ephyviewer/datasource/neosource.py
@@ -2,7 +2,7 @@
 """
 This module include some facilities to make data source from:
   * neo.rawio so on disk sources (signals, spikes, epoch...)
-  * neo objects (neo.AnalogSignal, neo.Epoch, neo.SpikeTrain
+  * neo objects in memory (neo.AnalogSignal, neo.Epoch, neo.SpikeTrain)
 
 """
 
@@ -93,7 +93,7 @@ def get_sources_from_neo_segment(neo_seg):
     sources = {'signal':[], 'epoch':[], 'spike':[],'event':[],}
     
     for neo_sig in neo_seg.analogsignals:
-        # noramly neo signals are group by same sampling rate in one AnalogSignal
+        # normally neo signals are grouped by same sampling rate in one AnalogSignal
         # with shape (nb_channel, nb_sample)
         sources['signal'].append(NeoAnalogSignalSource(neo_sig))
 

--- a/ephyviewer/eventlist.py
+++ b/ephyviewer/eventlist.py
@@ -8,7 +8,7 @@ from .myqt import QT
 import pyqtgraph as pg
 
 from .base import ViewerBase
-from .datasource import InMemoryEventSource
+from .datasource import InMemoryEventSource, NeoEventSource
 
 
 
@@ -35,6 +35,12 @@ class EventList(ViewerBase):
     @classmethod
     def from_numpy(cls, all_events, name):
         source = InMemoryEventSource(all_events)
+        view = cls(source=source, name=name)
+        return view
+        
+    @classmethod
+    def from_neo_events(cls, neo_events, name):    
+        source = NeoEventSource(neo_events)
         view = cls(source=source, name=name)
         return view
         

--- a/ephyviewer/mainviewer.py
+++ b/ephyviewer/mainviewer.py
@@ -229,7 +229,12 @@ def compose_mainviewer_from_sources(sources, mainviewer=None):
         view = EpochViewer(source=ep_source, name='epochs')
         mainviewer.add_view(view)
 
-        view = EventList(source=ep_source, name='Event list')
+    if 'event' in sources and len(sources['event']) > 0:
+        ev_source_list = sources['event']
+    else:
+        ev_source_list = sources['epoch']
+    for i, ev_source in enumerate(ev_source_list):
+        view = EventList(source=ev_source, name='Event list')
         mainviewer.add_view(view, location='bottom',  orientation='horizontal')
     
     

--- a/examples/viewers_with_neo_objects.py
+++ b/examples/viewers_with_neo_objects.py
@@ -1,10 +1,9 @@
 """
-Here an example to open viewer directly from neo objects.
+Here is an example of opening viewers directly from neo objects.
 
-There are two approach:
-   * create each viewer with class method (TraceViewer.from_ne_analogsignal, ...)
-   * magically create all source by providing the neo.Segment
-
+There are two approaches:
+   * create each viewer with class method (TraceViewer.from_neo_analogsignal, ...)
+   * magically create all sources by providing the neo.Segment
 
 """
 from ephyviewer import mkQApp, MainViewer, TraceViewer, SpikeTrainViewer, EpochViewer, EventList
@@ -16,7 +15,7 @@ from neo.test.generate_datasets import generate_one_simple_segment
 import neo
 
 
-# here with generate a segment with several object
+# here we generate a segment with several objects
 # (this is a bad example because it mimics old neo behavior for signals (one channel=one object))
 neo_seg = generate_one_simple_segment(supported_objects=[neo.Segment, neo.AnalogSignal, neo.Event, neo.Epoch, neo.SpikeTrain])
 
@@ -25,7 +24,7 @@ app = mkQApp()
 
 
 ##############################
-# case1 : object by object
+# case 1 : create viewers one at a time directly from neo objects in memory
 win = MainViewer(show_auto_scale=True)
 
 # from one neo.AnalogSignal
@@ -51,7 +50,7 @@ win.show()
 
 
 ##############################
-# case 2 : automagic create window from automagic sources
+# case 2 : automagically create data sources and a complete window from a neo segment
 sources = get_sources_from_neo_segment(neo_seg)
 win2 = compose_mainviewer_from_sources(sources)
 win2.show()

--- a/examples/viewers_with_neo_objects.py
+++ b/examples/viewers_with_neo_objects.py
@@ -7,7 +7,7 @@ There are two approach:
 
 
 """
-from ephyviewer import mkQApp, MainViewer, TraceViewer, SpikeTrainViewer, EpochViewer
+from ephyviewer import mkQApp, MainViewer, TraceViewer, SpikeTrainViewer, EpochViewer, EventList
 from ephyviewer import get_sources_from_neo_segment, compose_mainviewer_from_sources
 import numpy as np
 
@@ -18,7 +18,7 @@ import neo
 
 # here with generate a segment with several object
 # (this is a bad example because it mimics old neo behavior for signals (one channel=one object))
-neo_seg = generate_one_simple_segment(supported_objects=[neo.Segment, neo.AnalogSignal, neo.Epoch, neo.SpikeTrain])
+neo_seg = generate_one_simple_segment(supported_objects=[neo.Segment, neo.AnalogSignal, neo.Event, neo.Epoch, neo.SpikeTrain])
 
 # the global QT app
 app = mkQApp()
@@ -39,6 +39,10 @@ win.add_view(view2)
 # from several neo.Epoch 
 view3 = EpochViewer.from_neo_epochs(neo_seg.epochs, 'epochs')
 win.add_view(view3)
+
+# from several neo.Event
+view4 = EventList.from_neo_events(neo_seg.events, 'events')
+win.add_view(view4, location='bottom',  orientation='horizontal')
 
 win.show()
 


### PR DESCRIPTION
It seemed that `EventList.from_neo_events` was forgotten, so I put it in with 9673f51.

I noticed that `compose_mainviewer_from_sources` ignored `sources['event']` (if it existed) when creating the event list and instead used `sources['epoch']`. I think `sources['epoch']` is good to use if `sources['event']` does not exist at all, but if the user wants to use `compose_mainviewer_from_sources` to try out ephyviewer on their own Neo sources, it would be better to use events when they are provided. Commit f88c119 adds this functionality.